### PR TITLE
Fix IOF ID generation.

### DIFF
--- a/src/gpio-server.cpp
+++ b/src/gpio-server.cpp
@@ -57,9 +57,6 @@ GpioServer::~GpioServer() {
 }
 
 IOF_Channel_ID GpioServer::findNewID() {
-	if(active_IOF_channels.size() < numeric_limits<gpio::IOF_Channel_ID>::max()) {
-		return active_IOF_channels.size();
-	}
 	set<IOF_Channel_ID> used_ids;
 	for(const auto& [pin, channelinfo] : active_IOF_channels) {
 		used_ids.insert(channelinfo.id);

--- a/src/gpio-server.cpp
+++ b/src/gpio-server.cpp
@@ -63,12 +63,15 @@ IOF_Channel_ID GpioServer::findNewID() {
 	}
 	IOF_Channel_ID ret = 0;
 	for(const auto& id : used_ids) {
-		if(id > ret)
-			return ret;
+		if(id > ret) {
+			break;
+		}
 		ret++;
 	}
-	cerr << "[GPIO-Server] No new channel ID could be found! "
-			<< active_IOF_channels.size() << " items in use, what are you doing?" << endl;
+	if(ret == std::numeric_limits<IOF_Channel_ID>::max()) {
+		cerr << "[GPIO-Server] No new channel ID could be found! "
+			 << active_IOF_channels.size() << " items in use, what are you doing?" << endl;
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Using vector size may lead to known ID to be generated as "new" after channel with low ID is closed:
If there are two channels with IDs 0 and 1 and channel 0 is closed, the next new channel would receive ID 1, even though that already exists. Due to this, the client cannot properly process the received data.